### PR TITLE
chore(pkg): fix start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "lint": "eslint --ext .vue .",
-    "start": "node .out/server",
+    "start": "node .output/server",
     "test": "yarn lint --ext .vue"
   },
   "devDependencies": {


### PR DESCRIPTION
When build with `yarn build`, nuxt generate makes `.output` not `.out`